### PR TITLE
Use documented properties instead of hidden/deprecated ones

### DIFF
--- a/affinity/server.yaml
+++ b/affinity/server.yaml
@@ -26,5 +26,5 @@ resources:
   example_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: network_id }
+      network: { get_param: network_id }
 

--- a/affinity/servergroups.yaml
+++ b/affinity/servergroups.yaml
@@ -59,7 +59,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: example_net}
+      network: {get_resource: example_net}
       ip_version: 4
       cidr: 10.0.0.0/24
       allocation_pools:

--- a/cloudInit/userExample.yaml
+++ b/cloudInit/userExample.yaml
@@ -85,7 +85,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: [ example_subnet, example_router ]
     properties:
-      router_id: { get_resource: example_router }
+      router: { get_resource: example_router }
       subnet: { get_resource: example_subnet }
 
   example_floating_ip:

--- a/cloudInit/userExample.yaml
+++ b/cloudInit/userExample.yaml
@@ -55,7 +55,7 @@ resources:
   example_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: example_net}
+      network: { get_resource: example_net}
       security_groups: [ get_resource: allow_ssh ]
 
   example_net:
@@ -70,7 +70,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: example_net}
+      network: {get_resource: example_net}
       ip_version: 4
       cidr: 10.0.0.0/24
       allocation_pools:

--- a/coreOS/cluster.yaml
+++ b/coreOS/cluster.yaml
@@ -58,7 +58,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: [ coreos_subnet, coreos_router ]
     properties:
-      router_id: { get_resource: coreos_router }
+      router: { get_resource: coreos_router }
       subnet: { get_resource: coreos_subnet }
 
   coreos_group:

--- a/coreOS/cluster.yaml
+++ b/coreOS/cluster.yaml
@@ -33,7 +33,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: { get_resource: coreos_net }
+      network: { get_resource: coreos_net }
       ip_version: 4
       cidr: 10.0.0.0/8
       allocation_pools:

--- a/coreOS/instance.yaml
+++ b/coreOS/instance.yaml
@@ -26,7 +26,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       security_groups: [ { get_param: coreos_security_group }, default ]
-      network_id: { get_param: coreos_net }
+      network: { get_param: coreos_net }
 
   floating_ip:
     type: OS::Neutron::FloatingIP

--- a/createSecurityGroups/singleMachineDevEnv.yaml
+++ b/createSecurityGroups/singleMachineDevEnv.yaml
@@ -74,7 +74,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: [ example_subnet, example_router ]
     properties:
-      router_id: { get_resource: example_router }
+      router: { get_resource: example_router }
       subnet: { get_resource: example_subnet }
 
   example_floating_ip:

--- a/createSecurityGroups/singleMachineDevEnv.yaml
+++ b/createSecurityGroups/singleMachineDevEnv.yaml
@@ -45,7 +45,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       security_groups: [ get_resource: allow_static_ip ]
-      network_id: { get_resource: example_net}
+      network: { get_resource: example_net}
 
   example_net:
     type: OS::Neutron::Net
@@ -59,7 +59,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: example_net}
+      network: {get_resource: example_net}
       ip_version: 4
       cidr: 10.0.0.0/8
       allocation_pools:

--- a/createSecurityGroups/singleMachineProdEnv.yaml
+++ b/createSecurityGroups/singleMachineProdEnv.yaml
@@ -57,7 +57,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       security_groups: [ {get_resource: allow_http}, {get_resource: allow_https}, {get_resource: allow_static_ip} ]
-      network_id: { get_resource: example_net}
+      network: { get_resource: example_net}
 
   example_net:
     type: OS::Neutron::Net
@@ -71,7 +71,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: example_net}
+      network: {get_resource: example_net}
       ip_version: 4
       cidr: 10.0.0.0/24
       allocation_pools:

--- a/createSecurityGroups/singleMachineProdEnv.yaml
+++ b/createSecurityGroups/singleMachineProdEnv.yaml
@@ -86,7 +86,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: [ example_subnet, example_router ]
     properties:
-      router_id: { get_resource: example_router }
+      router: { get_resource: example_router }
       subnet: { get_resource: example_subnet }
 
   example_floating_ip:

--- a/example-setup/clustersetup.yaml
+++ b/example-setup/clustersetup.yaml
@@ -55,7 +55,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: syseleven_net}
+      network: {get_resource: syseleven_net}
       ip_version: 4
       cidr: 192.168.2.0/24
       allocation_pools:

--- a/example-setup/clustersetup.yaml
+++ b/example-setup/clustersetup.yaml
@@ -71,7 +71,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: [ syseleven_router ]
     properties:
-      router_id: { get_resource: syseleven_router }
+      router: { get_resource: syseleven_router }
       subnet: { get_resource: syseleven_subnet }
 
   ### LB Node as resource group ###

--- a/example-setup/dbserver.yaml
+++ b/example-setup/dbserver.yaml
@@ -73,4 +73,4 @@ resources:
     type: OS::Neutron::Port
     properties:
       name: dbserver port
-      network_id: { get_param: syseleven_net}
+      network: { get_param: syseleven_net}

--- a/example-setup/lb.yaml
+++ b/example-setup/lb.yaml
@@ -65,7 +65,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       name: lb port
-      network_id: { get_param: syseleven_net}
+      network: { get_param: syseleven_net}
       security_groups: 
         - { get_resource: allow_webtraffic }
         - default

--- a/example-setup/server.yaml
+++ b/example-setup/server.yaml
@@ -52,5 +52,5 @@ resources:
     type: OS::Neutron::Port
     properties:
       name: server port
-      network_id: { get_param: syseleven_net}
+      network: { get_param: syseleven_net}
 

--- a/example-setup/servicehost.yaml
+++ b/example-setup/servicehost.yaml
@@ -64,7 +64,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       name: servicehost port
-      network_id: { get_param: syseleven_net}
+      network: { get_param: syseleven_net}
       security_groups: 
         - { get_resource: allow_ssh } 
         - default

--- a/gettingStarted/sysElevenStackKickstart.yaml
+++ b/gettingStarted/sysElevenStackKickstart.yaml
@@ -157,7 +157,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: subnet
     properties:
-      router_id: { get_resource: router }
+      router: { get_resource: router }
       subnet: { get_resource: subnet }
 
   floating_ip:

--- a/gettingStarted/sysElevenStackKickstart.yaml
+++ b/gettingStarted/sysElevenStackKickstart.yaml
@@ -126,7 +126,7 @@ resources:
   port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: net}
+      network: { get_resource: net}
       security_groups: [ get_resource: allow_ssh ]
 
   net:
@@ -141,7 +141,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: net}
+      network: {get_resource: net}
       ip_version: 4
       cidr: 10.0.0.0/24
       allocation_pools:

--- a/lampServer/lamp.yaml
+++ b/lampServer/lamp.yaml
@@ -85,7 +85,7 @@ resources:
   port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: net}
+      network: { get_resource: net}
       security_groups: [ get_resource: allow_ssh, get_resource: allow_webtraffic ]
 
   net:
@@ -100,7 +100,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: net}
+      network: {get_resource: net}
       ip_version: 4
       cidr: 10.0.0.0/24
       allocation_pools:
@@ -116,7 +116,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: subnet
     properties:
-      router_id: { get_resource: router }
+      router: { get_resource: router }
       subnet: { get_resource: subnet }
 
   floating_ip:

--- a/sharedVolume/nfs-client.yaml
+++ b/sharedVolume/nfs-client.yaml
@@ -30,7 +30,7 @@ resources:
   syseleven_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: syseleven_net}
+      network: { get_param: syseleven_net}
       security_groups: [ {get_resource: allow_ssh}, default ]
   
   cloud-init-config:

--- a/sharedVolume/nfs-server.yaml
+++ b/sharedVolume/nfs-server.yaml
@@ -34,7 +34,7 @@ resources:
   syseleven_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: syseleven_net}
+      network: { get_param: syseleven_net}
       security_groups: [ {get_resource: allow_ssh}, default ]
   
   syseleven_floating_ip:

--- a/sharedVolume/stack.yaml
+++ b/sharedVolume/stack.yaml
@@ -40,7 +40,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: [ syseleven_subnet, syseleven_router, syseleven_net ]
     properties:
-      router_id: { get_resource: syseleven_router }
+      router: { get_resource: syseleven_router }
       subnet: { get_resource: syseleven_subnet }
 
   ### NFS Node as resource group ###

--- a/sharedVolume/stack.yaml
+++ b/sharedVolume/stack.yaml
@@ -25,7 +25,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: syseleven_net}
+      network: {get_resource: syseleven_net}
       ip_version: 4
       cidr: 10.10.10.0/8
       allocation_pools:

--- a/singleServer/example.yaml
+++ b/singleServer/example.yaml
@@ -55,7 +55,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: [ example_subnet, example_router, example_net ]
     properties:
-      router_id: { get_resource: example_router }
+      router: { get_resource: example_router }
       subnet: { get_resource: example_subnet }
 
 

--- a/singleServer/example.yaml
+++ b/singleServer/example.yaml
@@ -26,7 +26,7 @@ resources:
   example_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: example_net}
+      network: { get_resource: example_net}
 
   example_net:
     type: OS::Neutron::Net
@@ -40,7 +40,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: example_net}
+      network: {get_resource: example_net}
       ip_version: 4
       cidr: 10.0.0.0/24
       allocation_pools:

--- a/singleServerWithFixedIP/example.yaml
+++ b/singleServerWithFixedIP/example.yaml
@@ -38,7 +38,7 @@ resources:
   example_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: example_net}
+      network: { get_resource: example_net}
       security_groups: [ {get_resource: allow_ssh}, default ]
 
   example_net:
@@ -53,7 +53,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: example_net}
+      network: {get_resource: example_net}
       ip_version: 4
       cidr: 10.0.0.0/8
       allocation_pools:

--- a/singleServerWithFixedIP/example.yaml
+++ b/singleServerWithFixedIP/example.yaml
@@ -69,7 +69,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on:  example_subnet 
     properties:
-      router_id: { get_resource: example_router }
+      router: { get_resource: example_router }
       subnet: { get_resource: example_subnet }
 
   associate_my_ip:

--- a/singleServerWithFloatingIP/example.yaml
+++ b/singleServerWithFloatingIP/example.yaml
@@ -29,7 +29,7 @@ resources:
   example_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: network}
+      network: { get_resource: network}
       security_groups: [{ get_resource: server_security_group }]
 
   example_floating_ip:
@@ -50,7 +50,7 @@ resources:
       name: examplae_subnet
       dns_nameservers:
         - 37.123.105.117
-      network_id: {get_resource: network}
+      network: {get_resource: network}
       ip_version: 4
       cidr: 10.0.0.0/24
       allocation_pools:

--- a/singleServerWithFloatingIP/example.yaml
+++ b/singleServerWithFloatingIP/example.yaml
@@ -66,7 +66,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on:  subnet
     properties:
-      router_id: { get_resource: router }
+      router: { get_resource: router }
       subnet: { get_resource: subnet }
 
   server_security_group:

--- a/singleServerWithVolume/singleServerWithVolume.yaml
+++ b/singleServerWithVolume/singleServerWithVolume.yaml
@@ -70,7 +70,7 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on:  example_subnet
     properties:
-      router_id: { get_resource: router }
+      router: { get_resource: router }
       subnet: { get_resource: example_subnet }
 
   example_test_floating_ip:

--- a/singleServerWithVolume/singleServerWithVolume.yaml
+++ b/singleServerWithVolume/singleServerWithVolume.yaml
@@ -57,7 +57,7 @@ resources:
   example_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: example_net}
+      network: { get_resource: example_net}
       security_groups: [{ get_resource: server_security_group }]
 
   router:
@@ -91,7 +91,7 @@ resources:
       dns_nameservers:
         - 37.123.105.116
         - 37.123.105.117
-      network_id: {get_resource: example_net}
+      network: {get_resource: example_net}
       ip_version: 4
       cidr: 10.0.0.0/8
       allocation_pools:

--- a/subnetConnect/subnetConnect.yaml
+++ b/subnetConnect/subnetConnect.yaml
@@ -27,7 +27,7 @@ resources:
       dns_nameservers:
         - 8.8.8.8
         - 8.8.4.4
-      network_id: {get_resource: mgm_net}
+      network: {get_resource: mgm_net}
       ip_version: 4
       cidr: 10.0.0.0/8
       allocation_pools:
@@ -46,7 +46,7 @@ resources:
       dns_nameservers:
         - 8.8.4.4
         - 8.8.8.8
-      network_id: {get_resource: application_net}
+      network: {get_resource: application_net}
       ip_version: 4
       cidr: 192.168.2.0/24
       allocation_pools:
@@ -86,7 +86,7 @@ resources:
   mgm_node_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: mgm_net}
+      network: { get_resource: mgm_net}
       security_groups: [{ get_resource: server_security_group }]
 
   application_node:
@@ -103,7 +103,7 @@ resources:
   appserver_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_resource: application_net}
+      network: { get_resource: application_net}
       security_groups: [{ get_resource: server_security_group }]
 
   server_security_group:

--- a/subnetConnect/subnetConnect.yaml
+++ b/subnetConnect/subnetConnect.yaml
@@ -62,14 +62,14 @@ resources:
     type: OS::Neutron::RouterInterface
     depends_on: mgm_subnet
     properties:
-      router_id: { get_resource: router }
+      router: { get_resource: router }
       subnet: { get_resource: mgm_subnet }
 
   application_subnet_connect:
     type: OS::Neutron::RouterInterface
     depends_on: application_subnet
     properties:
-      router_id: { get_resource: router }
+      router: { get_resource: router }
       subnet: { get_resource: application_subnet }
 
   mgm_node:


### PR DESCRIPTION
Mitaka deprecated a lot of Properties which we are still using:

For OS::Neutron::RouterInterface:
Use router instead of router_id
Use subnet instead of subnet_id

For OS::Neutron::Port:
Use network instead of network_id

For OS::Neutron::Subnet:
Use network instead of network_id

For OS::Neutron::FloatingIP
Use floating_network instead of floating_network_id

Those properties still exist, but are hidden. That means they are automatically matched to the new properties, but this will not work for nested stacks and resource groups.

see also: https://bugs.launchpad.net/heat/+bug/1591186