### PR TITLE
Fix indention in subnet

### DIFF
--- a/singleServerWithVolume/singleServerWithVolume.yaml
+++ b/singleServerWithVolume/singleServerWithVolume.yaml
@@ -95,6 +95,6 @@ resources:
       ip_version: 4
       cidr: 10.0.0.0/8
       allocation_pools:
-      - {start: 10.0.0.10, end: 10.0.0.250}
+        - {start: 10.0.0.10, end: 10.0.0.250}
 
 


### PR DESCRIPTION
Hi,

just a small typo, the entry in the allocation pools needs to be indented.