### PR TITLE
Change jumphost flavor

### DIFF
--- a/gettingStarted/sysElevenStackKickstart.yaml
+++ b/gettingStarted/sysElevenStackKickstart.yaml
@@ -31,7 +31,7 @@ parameters:
    default: Ubuntu Server 16.04 LTS
  flavor:
    type: string
-   default: m1.micro
+   default: m1.tiny
  public_network:
    type: string
    default: ext-net


### PR DESCRIPTION
- the micro flavor should not be used anymore
- m1.tiny with 1cpu and 4gb ram is smallest flavor