### PR TITLE
Fix Consul initial join

### DIFF
--- a/example-setup/clustersetup-env-testing-small.yaml
+++ b/example-setup/clustersetup-env-testing-small.yaml
@@ -1,7 +1,7 @@
 # This parameter file is configured to be used with a 10 Core / 40 GB RAM quota provided by SysEleven GmbH.
 parameters:
   public_network: ext-net
-  image: Ubuntu 16.04 sys11-cloudimg amd64 
+  image: Ubuntu 16.04 LTS sys11 optimized 2018.03.21 
 
   # Used resources can be configures with the following parameters
   number_appservers: 2

--- a/example-setup/clustersetup-env.yaml
+++ b/example-setup/clustersetup-env.yaml
@@ -1,7 +1,7 @@
 # This parameter file is configured to be used with a 30 Core / 120 GB RAM quota provided by SysEleven GmbH.
 parameters:
   public_network: ext-net
-  image: Ubuntu 16.04 sys11-cloudimg amd64 
+  image: Ubuntu 16.04 LTS sys11 optimized 2018.03.21 
 
   # Used resources can be configures with the following parameters
   number_appservers: 4

--- a/example-setup/clustersetup.yaml
+++ b/example-setup/clustersetup.yaml
@@ -102,13 +102,15 @@ resources:
       resource_def: 
         type: servicehost.yaml
         properties:
+          metadata:
+            consul_main: 127.0.0.1
+            consul_mastertoken: {get_attr: [consul_mastertoken, value]}
+            consul_agenttoken: {get_attr: [consul_agenttoken, value]}
           name: servicehost%index%
           flavor: { get_param: flavor_servicehost }
           image: { get_param: image }
           syseleven_net: { get_resource: syseleven_net }
           public_network: { get_param: public_network }
-          consul_mastertoken: {get_attr: [consul_mastertoken, value]} 
-          consul_agenttoken: {get_attr: [consul_agenttoken, value]}
           ssh_keys: { get_param: ssh_keys }
 
   ### LB Node as resource group ###
@@ -121,13 +123,15 @@ resources:
       resource_def: 
         type: lb.yaml
         properties:
+          metadata:
+            consul_main: { list_join: [',', { get_attr: [servicehost_group, instance_ip] }] }
+            consul_mastertoken: {get_attr: [consul_mastertoken, value]}
+            consul_agenttoken: {get_attr: [consul_agenttoken, value]}
           name: lb%index%
           image: { get_param: image }
           flavor: { get_param: flavor_lb }
           syseleven_net: { get_resource: syseleven_net }
           public_network: { get_param: public_network }
-          consul_mastertoken: {get_attr: [consul_mastertoken, value]}
-          consul_agenttoken: {get_attr: [consul_agenttoken, value]}
           ssh_keys: { get_param: ssh_keys }
 
   ### DBserver Nodes as resource group ###
@@ -140,12 +144,14 @@ resources:
       resource_def: 
         type: dbserver.yaml
         properties:
+          metadata:
+            consul_main: { list_join: [',', { get_attr: [servicehost_group, instance_ip] }] }
+            consul_mastertoken: {get_attr: [consul_mastertoken, value]}
+            consul_agenttoken: {get_attr: [consul_agenttoken, value]}
           name: db%index%
           flavor: { get_param: flavor_dbserver }
           image: { get_param: image }
           syseleven_net: { get_resource: syseleven_net }
-          consul_mastertoken: {get_attr: [consul_mastertoken, value]}
-          consul_agenttoken: {get_attr: [consul_agenttoken, value]}
           ssh_keys: { get_param: ssh_keys }
 
   ### Appserver nodes as resource group ###
@@ -158,12 +164,14 @@ resources:
       resource_def: 
         type: server.yaml
         properties:
+          metadata:
+            consul_main: { list_join: [',', { get_attr: [servicehost_group, instance_ip] }] }
+            consul_mastertoken: {get_attr: [consul_mastertoken, value]}
+            consul_agenttoken: {get_attr: [consul_agenttoken, value]}
           name: app%index%
           flavor: { get_param: flavor_appserver }
           image: { get_param: image }
           syseleven_net: { get_resource: syseleven_net }
-          consul_mastertoken: {get_attr: [consul_mastertoken, value]}
-          consul_agenttoken: {get_attr: [consul_agenttoken, value]} 
           ssh_keys: { get_param: ssh_keys }
 
 outputs:

--- a/example-setup/dbserver.yaml
+++ b/example-setup/dbserver.yaml
@@ -9,12 +9,10 @@ parameters:
     type: string
   flavor:
     type: string
-  consul_mastertoken:
-    type: string
-  consul_agenttoken:
-    type: string
   ssh_keys:
     type: comma_delimited_list
+  metadata:
+    type: json
 
 resources:
 
@@ -24,7 +22,8 @@ resources:
     properties:
       name: { get_param: name }
       user_data_format: RAW
-      user_data: { get_resource: cloud-init-config }    
+      user_data: { get_resource: cloud-init-config }
+      metadata: { get_param: metadata }    
       image: { get_param: image }
       flavor: { get_param: flavor }
       networks:
@@ -36,8 +35,8 @@ resources:
    properties:
      cloud_config:
        runcmd:
-         - [ /root/install_generic.sh, { get_param: consul_mastertoken }, { get_param: consul_agenttoken } ]
-         - /root/install_dbserver.sh
+         - [ /root/install_generic.sh ]
+         - [ /root/install_dbserver.sh ]
        write_files:
          -  content: { get_file: scripts/install_generic.sh }
             permissions: 0700
@@ -64,3 +63,8 @@ resources:
     properties:
       name: dbserver port
       network: { get_param: syseleven_net }
+
+outputs:
+  instance_ip:
+    description: IP address of the deployed compute instance
+    value: { get_attr: [dbserver, first_address] }

--- a/example-setup/lb.yaml
+++ b/example-setup/lb.yaml
@@ -9,14 +9,12 @@ parameters:
     type: string
   flavor:
     type: string
-  consul_mastertoken:
-    type: string
-  consul_agenttoken:
-    type: string
   ssh_keys:
     type: comma_delimited_list
   public_network:
     type: string
+  metadata:
+    type: json
 
 resources:
   allow_webtraffic:
@@ -39,7 +37,8 @@ resources:
       flavor: { get_param: flavor }
       image: { get_param: image }
       user_data_format: RAW
-      user_data: { get_resource: cloud-init-config }    
+      user_data: { get_resource: cloud-init-config }
+      metadata: { get_param: metadata }  
       networks:
         - port: { get_resource: lb_port }
 
@@ -49,8 +48,8 @@ resources:
    properties:
      cloud_config:
        runcmd:
-         - [ /root/install_generic.sh, { get_param: consul_mastertoken }, { get_param: consul_agenttoken } ]
-         - /root/install_lb.sh
+         - [ /root/install_generic.sh ]
+         - [ /root/install_lb.sh ]
        write_files:
          -  content: { get_file: scripts/install_generic.sh }
             permissions: 0700
@@ -82,3 +81,7 @@ resources:
       floating_network: { get_param: public_network }
       port_id: { get_resource: lb_port }
 
+outputs:
+  instance_ip:
+    description: IP address of the deployed compute instance
+    value: { get_attr: [lbserver, first_address] }

--- a/example-setup/server.yaml
+++ b/example-setup/server.yaml
@@ -9,12 +9,10 @@ parameters:
     type: string
   flavor: 
     type: string
-  consul_mastertoken:
-    type: string
-  consul_agenttoken:
-    type: string
   ssh_keys:
     type: comma_delimited_list
+  metadata:
+    type: json
 
 resources:
 
@@ -26,7 +24,8 @@ resources:
       image: { get_param: image } 
       flavor: { get_param: flavor }
       user_data_format: RAW
-      user_data: { get_resource: cloud-init-config }    
+      user_data: { get_resource: cloud-init-config }
+      metadata: { get_param: metadata }  
       networks:
         - port: { get_resource: server_port }
 
@@ -36,8 +35,8 @@ resources:
    properties:
      cloud_config:
        runcmd:
-         - [ /root/install_generic.sh, { get_param: consul_mastertoken }, { get_param: consul_agenttoken } ]
-         - /root/install_appserver.sh
+         - [ /root/install_generic.sh ]
+         - [ /root/install_appserver.sh ]
        write_files:
          -  content: { get_file: scripts/install_generic.sh }
             permissions: 0700
@@ -59,3 +58,8 @@ resources:
       name: server port
       network: { get_param: syseleven_net}
 
+
+outputs:
+  instance_ip:
+    description: IP address of the deployed compute instance
+    value: { get_attr: [server, first_address] }

--- a/example-setup/servicehost.yaml
+++ b/example-setup/servicehost.yaml
@@ -9,15 +9,12 @@ parameters:
     type: string
   flavor: 
     type: string
-  consul_mastertoken:
-    type: string
-  consul_agenttoken:
-    type: string
   ssh_keys:
     type: comma_delimited_list
   public_network:
     type: string
-
+  metadata:
+    type: json
 
 resources:
 
@@ -39,7 +36,8 @@ resources:
       image: { get_param: image } 
       flavor: { get_param: flavor }
       user_data_format: RAW
-      user_data: { get_resource: cloud-init-config }    
+      user_data: { get_resource: cloud-init-config }
+      metadata: { get_param: metadata }    
       networks:
         - port: { get_resource: server_port }
 
@@ -49,8 +47,8 @@ resources:
    properties:
      cloud_config:
        runcmd:
-         - [ /root/install_generic.sh, { get_param: consul_mastertoken }, { get_param: consul_agenttoken } ]
-         - [ /root/install_deployhost.sh, { get_param: consul_mastertoken }, { get_param: consul_agenttoken } ]
+         - [ /root/install_generic.sh ]
+         - [ /root/install_deployhost.sh ]
        write_files:
          -  content: { get_file: scripts/install_generic.sh }
             permissions: 0700
@@ -82,4 +80,9 @@ resources:
     properties:
       floating_network: { get_param: public_network }
       port_id: { get_resource: server_port }
+
+outputs:
+  instance_ip:
+    description: IP address of the deployed compute instance
+    value: { get_attr: [server, first_address] }
 


### PR DESCRIPTION
- Use metadata instead of script parameter
- Use metadata to inject server and client / agent token
- Adjust bash scripts to support metadata and remove depricated lines from heat template